### PR TITLE
fix label workflow [skip netlify]

### DIFF
--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -2,6 +2,7 @@ name: Label
 
 on:
   pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
     branches:
       - main
 


### PR DESCRIPTION
The require label workflow was not working consistently. This changes the pull request `types` parameter to match the example from https://github.com/mheap/github-action-required-labels