### PR TITLE
switch to cloned auto release project with change to commit logic

### DIFF
--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -30,7 +30,7 @@ jobs:
           message: "bump version: ${{ steps.bump.outputs.new_version }}"
       - name: Create Release
         id: release
-        uses: justincy/github-action-npm-release@2.0.2
+        uses: btjones/github-action-npm-release@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Release Details


### PR DESCRIPTION
Switches to using a custom fork of [github-action-npm-release](https://github.com/btjones/github-action-npm-release). This fork has a change to use latest commit hash instead of GITHUB_SHA when creating new release. Because we're updating the version in our workflow and committing that change, this will point our release at that commit instead of the previous commit that kicked off the action.