### PR TITLE
split bump and release into two different actions

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,4 +1,4 @@
-name: Version & Release
+name: Bump Version
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   bump:
-    name: Bump Package Version & Create Release
+    name: Bump Package Version
     # only run if the PR closed by merging
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
@@ -28,11 +28,3 @@ jobs:
         with:
           branch: main
           message: "bump version: ${{ steps.bump.outputs.new_version }}"
-      - name: Create Release
-        id: release
-        uses: justincy/github-action-npm-release@2.0.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Release Details
-        if: ${{ steps.release.outputs.released == 'true' }}
-        run: echo Release ID ${{ steps.release.outputs.release_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  bump:
+    name: Create Release
+    # runs when commit message starts with 'bump version:'
+    if: "startsWith(github.event.head_commit.message, 'bump version:')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Create Release
+        id: release
+        uses: justincy/github-action-npm-release@2.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release Details
+        if: ${{ steps.release.outputs.released == 'true' }}
+        run: echo Release ID ${{ steps.release.outputs.release_id }}


### PR DESCRIPTION
Previously the release was not pointing to the version bump commit. Hopefully this will resolve that issue so that the release points to the correct commit.