### PR TITLE
use personal access token instead of github token for actions

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.AXILLA_PAT }}
       - uses: copapow/version-bump-package@v1
         id: bump
         with:
@@ -23,8 +25,9 @@ jobs:
           minor_label: minor
           patch_label: patch
           default_branch: main
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.AXILLA_PAT }}
       - uses: EndBug/add-and-commit@v7.2.1
         with:
           branch: main
           message: "bump version: ${{ steps.bump.outputs.new_version }}"
+          github_token: ${{ secrets.AXILLA_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.AXILLA_PAT }}
       - name: Create Release
         id: release
         uses: justincy/github-action-npm-release@2.0.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AXILLA_PAT }}
       - name: Release Details
         if: ${{ steps.release.outputs.released == 'true' }}
         run: echo Release ID ${{ steps.release.outputs.release_id }}


### PR DESCRIPTION
After splitting the bump and release actions, the release task was not being triggered by the push that happened in the bump action. Turns out you have to use a personal access token or else actions will not trigger other subsequent actions.

Further details:

- https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854
- https://github.community/t/push-from-action-even-with-pat-does-not-trigger-action/17622