### PR TITLE
update pixlet-aws to v0.17.15

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tests:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       PIXLET_BINARY: pixlet-github
       PIXLET_BINARY_PATH: ./functions/axilla/pixlet/

--- a/functions/axilla/pixlet/README.md
+++ b/functions/axilla/pixlet/README.md
@@ -2,7 +2,7 @@
 
 ## `pixlet-aws`
 
-Version: 0.17.2 (commit: [2fd1466](https://github.com/tidbyt/pixlet/commit/2fd1466d2ca6a4c9757a1d6b3c9edbf7989a24bd))
+Version: 0.17.15 (commit: [ec2acb3](https://github.com/tidbyt/pixlet/commit/ec2acb3968d0038ae7d22999f18ea7f1d700227e))
 
 `pixlet-aws` is [built from source](https://github.com/tidbyt/pixlet/blob/2eaa1e34257b954a778a7878e21d9837e3befb52/BUILD.md) using an Amazon EC2 instance.
 

--- a/functions/axilla/pixlet/README.md
+++ b/functions/axilla/pixlet/README.md
@@ -2,7 +2,7 @@
 
 ## `pixlet-aws`
 
-Version: 0.17.15 (commit: [ec2acb3](https://github.com/tidbyt/pixlet/commit/ec2acb3968d0038ae7d22999f18ea7f1d700227e))
+Version: ~0.17.15 (commit: [c53e5a4](https://github.com/tidbyt/pixlet/commit/c53e5a4d884b9f3422ed20889a3c7b38392d2b39))
 
 `pixlet-aws` is [built from source](https://github.com/tidbyt/pixlet/blob/2eaa1e34257b954a778a7878e21d9837e3befb52/BUILD.md) using an Amazon EC2 instance.
 


### PR DESCRIPTION
- Updates `pixlet-aws` to ~ version 0.17.15 (actually a couple commits newer than that version)
- Updated unit tests to run on ubuntu-22.04 (previously was on ubuntu-20.04
- Attempted to update `pixlet-github` to the latest pixlet version but that's still failing. Reverted that change.